### PR TITLE
Bundle the license file in distributed .tar.gz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     include_dirs=[numpy.get_include()],
     packages=['tslearn'],
     package_data={"tslearn": [".cached_datasets/Trace.npz"]},
+    data_files = [("", ["LICENSE"])],
     install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython'],
     ext_modules=ext,
     cmdclass={'build_ext': _build_ext},


### PR DESCRIPTION
This PR makes sure that the LICENSE file is included in .tar.gz distributed on PyPi. Approach based on this [SO question](https://stackoverflow.com/questions/9977889/how-to-include-license-file-in-setup-py-script), the alternative would be to write a `MANIFEST.in` file.

The corresponding issues was raised while packaging tslearn in conda-forge